### PR TITLE
[比較與ws套件官方寫法]Private chat2

### DIFF
--- a/app.js
+++ b/app.js
@@ -17,6 +17,7 @@ app.engine("handlebars", exhbs({
 app.set("view engine", "handlebars")
 
 app.use(bodyParser.urlencoded({ extended: true }))
+
 // 設定靜態檔案路徑
 // 但我不確定是不是要跟下面的upload一樣在前面加個'public'才對? 不知道目前這樣會不會蓋到upload的路徑? 需要測一下。
 app.use(express.static('public'))
@@ -41,25 +42,22 @@ const server = app.listen(port, () => console.log(`Example app listening on port
 
 // websocket設定
 const SocketServer = require('ws').Server
-
 //將 把app交給SocketServer開啟 WebSocket 的服務
 const wss = new SocketServer({ server })
 
 // 當WebSocket從外面連結時執行
 wss.on('connection', ws => {
   console.log('Client connected')
-
   /* 如果不想只等Client發訊息，Server才回覆，可以用setInterval一直主動發訊息給Client(下面示範一直發出當前時間)
   const sendNowTime = setInterval(()=>{
     ws.send(String(new Date()))
   }, 1000)
   */
-  
   // 對message進行監聽，接收從Client送進來的訊息
   ws.on('message', data => {
-    // data是Client發送的訊息，接著把訊息原封不動送回去給Client，但是這個只能針對個人，如果A傳給server，server會再回傳給A而已
+    /* data是Client發送的訊息，接著把訊息原封不動送回去給Client，但是這個只能針對個人，如果A傳給server，server會再回傳給A而已
     ws.send(data)
-    
+    */ 
     // 承上，如果需要傳給所有在聊天室的人則要用wss.clients
     let clients = wss.clients
       // 聊天室裡會有很多人，所以用迴圈發訊息給所有Client
@@ -71,6 +69,9 @@ wss.on('connection', ws => {
   // 連結關閉時執行
   ws.on('close', () => {
     console.log('Close connected ')
+
+    // 最後把所有的聊天訊息存到資料庫
+
   })
 })
 

--- a/app.js
+++ b/app.js
@@ -40,40 +40,7 @@ app.use((req, res, next) => {
 // 要把原本app.listen包起來
 const server = app.listen(port, () => console.log(`Example app listening on port ${port}!`))
 
-// websocket設定
-const SocketServer = require('ws').Server
-//將 把app交給SocketServer開啟 WebSocket 的服務
-const wss = new SocketServer({ server })
-
-// 當WebSocket從外面連結時執行
-wss.on('connection', ws => {
-  console.log('Client connected')
-  /* 如果不想只等Client發訊息，Server才回覆，可以用setInterval一直主動發訊息給Client(下面示範一直發出當前時間)
-  const sendNowTime = setInterval(()=>{
-    ws.send(String(new Date()))
-  }, 1000)
-  */
-  // 對message進行監聽，接收從Client送進來的訊息
-  ws.on('message', data => {
-    /* data是Client發送的訊息，接著把訊息原封不動送回去給Client，但是這個只能針對個人，如果A傳給server，server會再回傳給A而已
-    ws.send(data)
-    */ 
-    // 承上，如果需要傳給所有在聊天室的人則要用wss.clients
-    let clients = wss.clients
-      // 聊天室裡會有很多人，所以用迴圈發訊息給所有Client
-      clients.forEach(client=> {
-        client.send(data)
-      })
-  })
-  
-  // 連結關閉時執行
-  ws.on('close', () => {
-    console.log('Close connected ')
-
-    // 最後把所有的聊天訊息存到資料庫
-
-  })
-})
+require('./config/websocketConfig').websocket(server)
 
 require("./routes/index")(app, passport)
 module.exports = app

--- a/app.js
+++ b/app.js
@@ -40,7 +40,95 @@ app.use((req, res, next) => {
 // 要把原本app.listen包起來
 const server = app.listen(port, () => console.log(`Example app listening on port ${port}!`))
 
-require('./config/websocketConfig').websocket(server)
+// require('./config/websocketConfig').websocket(server)
+
+// --- websocket專區(參照ws套件官方範例) ---
+const http = require('http')
+const uuid = require('uuid')
+const sessionParser = session({
+  saveUninitialized: false,
+  secret: '$eCuRiTy',
+  resave: false
+});
+const Websocket = require('../..')
+const map = new Map()
+
+let user = {} // 連接用戶數
+let online = 0 // 在線人數
+
+//把app交給SocketServer開啟 WebSocket 的服務
+const wss = new Websocket.Server({clientTracking: false, noserver: true})
+/*const wss = new SocketServer({ server, verifyClient: yan })
+function yan(info) {
+  console.log(info.req.headers.cookie)
+  let infoUrl = info.req.url
+  console.log('通過連接' + infoUrl)
+  return true
+}*/
+
+// 當WebSocket從外面連結時執行
+wss.on('connection', (ws, req) => {
+  console.log('Client connected')
+  online = wss._server._connections
+  console.log('目前在線', online, '個連接')
+  ws.send('目前在線' + online + '個連接')
+  
+  let url = req.url
+  let chatHost = url.split('/')[2] //發起聊天的人的id
+  // 把發起聊天的人的ws存在伺服器
+  if (chatHost) {
+    user[chatHost] = ws
+  }
+  // console.log(user)
+  let chattedUser = url.split('/')[3] //被聊天的對象的id
+
+  // [待開發]首次連接就先去撈歷史訊息給Client
+
+  // 對message進行監聽，接收從Client送進來的訊息
+  ws.on('message', data => {
+    console.log('收到' + url + '的消息' + data)
+    // 判斷有沒有被聊天的對象
+    if (chattedUser) {
+      // 會去查看被聊天的對象有沒有被存在user裡了
+      if (user[chattedUser]) {
+        /* 當對方沒有連線的時候，對方的readyState會變成3，只是我不確定它是在哪個時候存進去把1變3的，
+        照理說user這個物件是在wss connection連接的時候就已經把所屬的ws塞進去了，
+        我也沒有在斷線的時候，把對方所屬的readyState塞進去user裡，應該是不會被更新成3?
+        用console發現好像是對方斷線的時候，會自動連動更新原本存在user裡的readyState?
+        */
+        if (user[chattedUser].readyState === 1) {
+          user[chattedUser].send(data) // 把訊息送給被聊天的對象
+          ws.send(data) // 也把訊息送回給發起聊天的人
+          ws.send('發送成功')
+
+        } else {
+          ws.send('對方斷線')
+        }
+      } else {
+        ws.send('找不到被聊天的使用者')
+      }
+    } else { // 如果沒有被聊天的對象，就會變成群聊發送
+      let clients = wss.clients
+      // 聊天室裡會有很多人，所以用迴圈發訊息給所有Client
+      clients.forEach(client => {
+        if (client !== ws && client.readyState === WebSocket.Open) {
+          client.send(data)
+        }
+
+      })
+    }
+  })
+
+  // 連結關閉時執行
+  ws.on('close', () => {
+    console.log('Close connected ')
+    // console.log(user)
+    // [待開發]最後把所有的聊天訊息存到資料庫(要另外新建一張資料表專門存訊息)
+
+  })
+})
+
+
 
 require("./routes/index")(app, passport)
 module.exports = app

--- a/app.js
+++ b/app.js
@@ -8,6 +8,8 @@ const flash = require("connect-flash")
 const methodOverride = require("method-override")
 const app = express()
 const port = 3000
+const http = require('http')
+const server = http.createServer(app)
 
 app.use(methodOverride("_method"))
 app.engine("handlebars", exhbs({
@@ -23,7 +25,8 @@ app.use(bodyParser.urlencoded({ extended: true }))
 app.use(express.static('public'))
 app.use('/upload', express.static(__dirname + '/upload'))
 
-app.use(session({name:'QQQ', secret: "12345", resave: false, saveUninitialized: false }))
+const sessionParser = session({secret: "12345", resave: false, saveUninitialized: false })
+app.use(sessionParser)
 app.use(flash())
 
 app.use(passport.initialize())
@@ -37,133 +40,16 @@ app.use((req, res, next) => {
   next()
 })
 
+// 下面這三行是用在官方寫法的server是用http時，那後面的app就都要改成server
+// const http = require('http')
+// const Websocket = require('ws')
+// const server = http.createServer(app)
+
 require("./routes/index")(app, passport)
+ require('./config/websocketConfig').websocket(app, sessionParser)
+
+
+
+
+
 module.exports = app
-
-// 要把原本app.listen包起來
-// const server = app.listen(port, () => console.log(`Example app listening on port ${port}!`))
-
-/*
-// ------ 我們看網路其他人的寫法 ------
-const SocketServer = require('ws').Server
-let user = {} // 連接用戶數
-let online = 0 // 在線人數
-
-//把app交給SocketServer開啟 WebSocket 的服務
-const wss = new SocketServer({ server, verifyClient: yan })
-function yan(info) {
-  console.log(info.req.headers.cookie)
-  let infoUrl = info.req.url
-  console.log('通過連接' + infoUrl)
-  return true
-}
-
-// 當WebSocket從外面連結時執行
-wss.on('connection', (ws, req) => {
-  console.log('Client connected')
-  online = wss._server._connections
-  console.log('目前在線', online, '個連接')
-  ws.send('目前在線' + online + '個連接')
-  
-  let url = req.url
-  let chatHost = url.split('/')[2] //發起聊天的人的id
-  // 把發起聊天的人的ws存在伺服器
-  if (chatHost) {
-    user[chatHost] = ws
-  }
-  // console.log(user)
-  let chattedUser = url.split('/')[3] //被聊天的對象的id
-
-  // [待開發]首次連接就先去撈歷史訊息給Client
-
-  // 對message進行監聽，接收從Client送進來的訊息
-  ws.on('message', data => {
-    console.log('收到' + url + '的消息' + data)
-    // 判斷有沒有被聊天的對象
-    if (chattedUser) {
-      // 會去查看被聊天的對象有沒有被存在user裡了
-      if (user[chattedUser]) {
-        // 當對方沒有連線的時候，對方的readyState會變成3，只是我不確定它是在哪個時候存進去把1變3的，
-        // 照理說user這個物件是在wss connection連接的時候就已經把所屬的ws塞進去了，
-        // 我也沒有在斷線的時候，把對方所屬的readyState塞進去user裡，應該是不會被更新成3?
-        // 用console發現好像是對方斷線的時候，會自動連動更新原本存在user裡的readyState?
-        
-        if (user[chattedUser].readyState === 1) {
-          user[chattedUser].send(data) // 把訊息送給被聊天的對象
-          ws.send(data) // 也把訊息送回給發起聊天的人
-          ws.send('發送成功')
-
-        } else {
-          ws.send('對方斷線')
-        }
-      } else {
-        ws.send('找不到被聊天的使用者')
-      }
-    } else { // 如果沒有被聊天的對象，就會變成群聊發送
-      let clients = wss.clients
-      // 聊天室裡會有很多人，所以用迴圈發訊息給所有Client
-      clients.forEach(client => {
-        if (client !== ws && client.readyState === WebSocket.Open) {
-          client.send(data)
-        }
-
-      })
-    }
-  })
-
-  // 連結關閉時執行
-  ws.on('close', () => {
-    console.log('Close connected ')
-    // console.log(user)
-    // [待開發]最後把所有的聊天訊息存到資料庫(要另外新建一張資料表專門存訊息)
-
-  })
-})
-*/
-
-// ------ 參照ws套件官方範例) ------
-const uuid = require('uuid')
-const http = require('http')
-const Websocket = require('ws')
-const server = http.createServer(app)
-const wss = new Websocket.Server({port: 3001, clientTracking: false, noserver: true})
-
-server.on('upgrade', function(request, socket, head) {
-  console.log(`parsing session from request...`)
-  
-  sessionParser(request, {} ,() => {
-    console.log(request.session)
-    if (!request.session.userId) {
-      // socket.destroy()
-      return
-    }
-    console.log('session is parsed!')
-
-    wss.handleUpgrade(request, socket, head, function(ws) {
-      wss.emit('connection', ws, request);
-    })
-  })
-})
-
-wss.on('connection', function(ws, request) {
-  console.log('連接建立')
-  ws.send('連接建立')
-  const userId = request.session.userId
-  map.set(userId, ws)
-  ws.on('message', function(message) {
-    //
-    // Here we can now use session parameters.
-    //
-    console.log(`Received message ${message} from user ${userId}`)
-  })
-
-  ws.on('close', function() {
-    map.delete(userId)
-  })
-})
-
-server.listen(3000, function() {
-  console.log('Listening on http://localhost:3000');
-});
-
-

--- a/app.js
+++ b/app.js
@@ -40,16 +40,6 @@ app.use((req, res, next) => {
   next()
 })
 
-// 下面這三行是用在官方寫法的server是用http時，那後面的app就都要改成server
-// const http = require('http')
-// const Websocket = require('ws')
-// const server = http.createServer(app)
-
 require("./routes/index")(app, passport)
- require('./config/websocketConfig').websocket(app, sessionParser)
-
-
-
-
-
+require('./config/websocketConfig').websocket(app, sessionParser, server)
 module.exports = app

--- a/app.js
+++ b/app.js
@@ -5,10 +5,7 @@ const bodyParser = require("body-parser")
 const passport = require("./config/passport")
 const session = require("express-session")
 const flash = require("connect-flash")
-
 const methodOverride = require("method-override")
-
-
 const app = express()
 const port = 3000
 
@@ -20,11 +17,10 @@ app.engine("handlebars", exhbs({
 app.set("view engine", "handlebars")
 
 app.use(bodyParser.urlencoded({ extended: true }))
+// 設定靜態檔案路徑
+// 但我不確定是不是要跟下面的upload一樣在前面加個'public'才對? 不知道目前這樣會不會蓋到upload的路徑? 需要測一下。
+app.use(express.static('public'))
 app.use('/upload', express.static(__dirname + '/upload'))
-
-
-app.use(methodOverride("_method"))
-
 
 app.use(session({ secret: "12345", resave: false, saveUninitialized: false }))
 app.use(flash())
@@ -40,8 +36,43 @@ app.use((req, res, next) => {
   next()
 })
 
-app.listen(port, () => console.log(`Example app listening on port ${port}!`))
+// 要把原本app.listen包起來
+const server = app.listen(port, () => console.log(`Example app listening on port ${port}!`))
 
+// websocket設定
+const SocketServer = require('ws').Server
+
+//將 把app交給SocketServer開啟 WebSocket 的服務
+const wss = new SocketServer({ server })
+
+// 當WebSocket從外面連結時執行
+wss.on('connection', ws => {
+  console.log('Client connected')
+
+  /* 如果不想只等Client發訊息，Server才回覆，可以用setInterval一直主動發訊息給Client(下面示範一直發出當前時間)
+  const sendNowTime = setInterval(()=>{
+    ws.send(String(new Date()))
+  }, 1000)
+  */
+  
+  // 對message進行監聽，接收從Client送進來的訊息
+  ws.on('message', data => {
+    // data是Client發送的訊息，接著把訊息原封不動送回去給Client，但是這個只能針對個人，如果A傳給server，server會再回傳給A而已
+    ws.send(data)
+    
+    // 承上，如果需要傳給所有在聊天室的人則要用wss.clients
+    let clients = wss.clients
+      // 聊天室裡會有很多人，所以用迴圈發訊息給所有Client
+      clients.forEach(client=> {
+        client.send(data)
+      })
+  })
+  
+  // 連結關閉時執行
+  ws.on('close', () => {
+    console.log('Close connected ')
+  })
+})
 
 require("./routes/index")(app, passport)
 module.exports = app

--- a/app.js
+++ b/app.js
@@ -23,7 +23,7 @@ app.use(bodyParser.urlencoded({ extended: true }))
 app.use(express.static('public'))
 app.use('/upload', express.static(__dirname + '/upload'))
 
-app.use(session({ secret: "12345", resave: false, saveUninitialized: false }))
+app.use(session({name:'QQQ', secret: "12345", resave: false, saveUninitialized: false }))
 app.use(flash())
 
 app.use(passport.initialize())
@@ -127,15 +127,6 @@ const http = require('http')
 const Websocket = require('ws')
 const server = http.createServer(app)
 const wss = new Websocket.Server({port: 3001, clientTracking: false, noserver: true})
-
-const sessionParser = session({
-  
-  saveUninitialized: false,
-  secret: '$eCuRiTy',
-  resave: false
-});
-
-app.use(sessionParser)
 
 server.on('upgrade', function(request, socket, head) {
   console.log(`parsing session from request...`)

--- a/config/websocketConfig.js
+++ b/config/websocketConfig.js
@@ -1,81 +1,131 @@
-const SocketServer = require('ws').Server
+// const SocketServer = require('ws').Server
+
 
 const websocket = {
-    websocket: function(server) {
-      let user = {} // 連接用戶數
-      let online = 0 // 在線人數
-      
-      //把app交給SocketServer開啟 WebSocket 的服務
-      const wss = new SocketServer({ server , verifyClient: yan})
-      function yan(info) {
-        console.log(info.req.headers.cookie)
-        let infoUrl = info.req.url
-        console.log('通過連接'+ infoUrl)
-        return true
-      } 
-
-      // 當WebSocket從外面連結時執行
-      wss.on('connection', (ws, req) => {
-        console.log('Client connected')
-        online = wss._server._connections
-        console.log('目前在線', online, '個連接')
-        ws.send('目前在線' + online + '個連接')
-        
-        let url = req.url
-        let chatHost = url.split('/')[2] //發起聊天的人的id
-        // 把發起聊天的人的ws存在伺服器
-        if (chatHost) {
-          user[chatHost] = ws
+  websocket: function (app, sessionParser) {
+    const Websocket = require('ws')
+    const http = require('http')
+    const server = http.createServer(app)
+    const map = new Map()
+    
+    const verifyClientFn = function(info) {
+      console.log(info.req.headers.cookie)
+      let infoUrl = info.req.url
+      console.log('通過連接'+ infoUrl)
+      return true
+    } 
+    const wss = new Websocket.Server({ port: 3001, clientTracking: false, noserver: true, verifyClient: verifyClientFn })
+    
+    server.on('upgrade', function (request, socket, head) {
+      console.log(`parsing session from request...`)
+      sessionParser(request, {}, () => {
+        console.log('websocket拿到的', request.session)
+        if (!request.session.userId) {
+          socket.destroy()
+          return
         }
-        // console.log(user)
-        let chattedUser = url.split('/')[3] //被聊天的對象的id
-        
-        // [待開發]首次連接就先去撈歷史訊息給Client
-
-        // 對message進行監聽，接收從Client送進來的訊息
-        ws.on('message', data => {
-          console.log('收到' + url + '的消息'+ data)
-          // 判斷有沒有被聊天的對象
-          if(chattedUser) {
-            // 會去查看被聊天的對象有沒有被存在user裡了
-            if (user[chattedUser]) {
-              /* 當對方沒有連線的時候，對方的readyState會變成3，只是我不確定它是在哪個時候存進去把1變3的，
-              照理說user這個物件是在wss connection連接的時候就已經把所屬的ws塞進去了，
-              我也沒有在斷線的時候，把對方所屬的readyState塞進去user裡，應該是不會被更新成3?
-              用console發現好像是對方斷線的時候，會自動連動更新原本存在user裡的readyState?
-              */
-              if (user[chattedUser].readyState === 1) {
-                user[chattedUser].send(data) // 把訊息送給被聊天的對象
-                ws.send(data) // 也把訊息送回給發起聊天的人
-                ws.send('發送成功')
-                
-              } else {
-                ws.send('對方斷線')
-              }
-            } else {
-              ws.send('找不到被聊天的使用者')
-            }
-          } else { // 如果沒有被聊天的對象，就會變成群聊發送
-            let clients = wss.clients
-            // 聊天室裡會有很多人，所以用迴圈發訊息給所有Client
-            clients.forEach(client=> {
-              if (client !==ws && client.readyState === WebSocket.Open) {
-                client.send(data)
-              }
-              
-            })
-          }
-        })
-        
-        // 連結關閉時執行
-        ws.on('close', () => {
-          console.log('Close connected ')
-          // console.log(user)
-          // [待開發]最後把所有的聊天訊息存到資料庫(要另外新建一張資料表專門存訊息)
-
+        console.log('session is parsed!')
+        wss.handleUpgrade(request, socket, head, function (ws) {
+          wss.emit('connection', ws, request)
         })
       })
-    }
+    })
+
+    wss.on('connection', function (ws, request) {
+      console.log('連接建立')
+      ws.send('連接建立')
+      const userId = request.session.passport.user
+      console.log('這是wss.clients', wss.clients)
+      map.set(userId, ws)
+      ws.on('message', function (message) {
+        //
+        // Here we can now use session parameters.
+        //
+        console.log(`Received message ${message} from user ${userId}`)
+      })
+
+      ws.on('close', function () {
+        map.delete(userId)
+      })
+    })
+
+    server.listen(3000, function() {
+      console.log('Listening on http://localhost:3000');
+    })
+    // let user = {} // 連接用戶數
+    // let online = 0 // 在線人數
+
+    // //把app交給SocketServer開啟 WebSocket 的服務
+    // const wss = new SocketServer({ server , verifyClient: yan})
+    // function yan(info) {
+    //   console.log(info.req.headers.cookie)
+    //   let infoUrl = info.req.url
+    //   console.log('通過連接'+ infoUrl)
+    //   return true
+    // } 
+
+    // // 當WebSocket從外面連結時執行
+    // wss.on('connection', (ws, req) => {
+    //   console.log('Client connected')
+    //   online = wss._server._connections
+    //   console.log('目前在線', online, '個連接')
+    //   ws.send('目前在線' + online + '個連接')
+
+    //   let url = req.url
+    //   let chatHost = url.split('/')[2] //發起聊天的人的id
+    //   // 把發起聊天的人的ws存在伺服器
+    //   if (chatHost) {
+    //     user[chatHost] = ws
+    //   }
+    //   // console.log(user)
+    //   let chattedUser = url.split('/')[3] //被聊天的對象的id
+
+    //   // [待開發]首次連接就先去撈歷史訊息給Client
+
+    //   // 對message進行監聽，接收從Client送進來的訊息
+    //   ws.on('message', data => {
+    //     console.log('收到' + url + '的消息'+ data)
+    //     // 判斷有沒有被聊天的對象
+    //     if(chattedUser) {
+    //       // 會去查看被聊天的對象有沒有被存在user裡了
+    //       if (user[chattedUser]) {
+    //         /* 當對方沒有連線的時候，對方的readyState會變成3，只是我不確定它是在哪個時候存進去把1變3的，
+    //         照理說user這個物件是在wss connection連接的時候就已經把所屬的ws塞進去了，
+    //         我也沒有在斷線的時候，把對方所屬的readyState塞進去user裡，應該是不會被更新成3?
+    //         用console發現好像是對方斷線的時候，會自動連動更新原本存在user裡的readyState?
+    //         */
+    //         if (user[chattedUser].readyState === 1) {
+    //           user[chattedUser].send(data) // 把訊息送給被聊天的對象
+    //           ws.send(data) // 也把訊息送回給發起聊天的人
+    //           ws.send('發送成功')
+
+    //         } else {
+    //           ws.send('對方斷線')
+    //         }
+    //       } else {
+    //         ws.send('找不到被聊天的使用者')
+    //       }
+    //     } else { // 如果沒有被聊天的對象，就會變成群聊發送
+    //       let clients = wss.clients
+    //       // 聊天室裡會有很多人，所以用迴圈發訊息給所有Client
+    //       clients.forEach(client=> {
+    //         if (client !==ws && client.readyState === WebSocket.Open) {
+    //           client.send(data)
+    //         }
+
+    //       })
+    //     }
+    //   })
+
+    //   // 連結關閉時執行
+    //   ws.on('close', () => {
+    //     console.log('Close connected ')
+    //     // console.log(user)
+    //     // [待開發]最後把所有的聊天訊息存到資料庫(要另外新建一張資料表專門存訊息)
+
+    //   })
+    // })
+  }
 }
 
 module.exports = websocket

--- a/config/websocketConfig.js
+++ b/config/websocketConfig.js
@@ -1,0 +1,74 @@
+const SocketServer = require('ws').Server
+
+const websocket = {
+    websocket: function(server) {
+      let user = {} // 連接用戶數
+      let online = 0 // 在線人數
+      
+      //把app交給SocketServer開啟 WebSocket 的服務
+      const wss = new SocketServer({ server })
+
+      // 當WebSocket從外面連結時執行
+      wss.on('connection', (ws, req) => {
+        console.log('Client connected')
+        online = wss._server._connections
+        console.log('目前在線', online, '個連接')
+        ws.send('目前在線' + online + '個連接')
+        
+        let url = req.url
+        let chatHost = url.split('/')[2] //發起聊天的人的id
+        // 把發起聊天的人的ws存在伺服器
+        if (chatHost) {
+          user[chatHost] = ws
+        }
+        console.log(user)
+        let chattedUser = url.split('/')[3] //被聊天的對象的id
+        
+        // [待開發]首次連接就先去撈歷史訊息給Client
+
+        // 對message進行監聽，接收從Client送進來的訊息
+        ws.on('message', data => {
+          console.log('收到' + url + '的消息'+ data)
+          // 判斷有沒有被聊天的對象
+          console.log(user)
+          if(chattedUser) {
+            // 會去查看被聊天的對象有沒有被存在user裡了
+            if (user[chattedUser]) {
+              /* 當對方沒有連線的時候，對方的readyState會變成3，只是我不確定它是在哪個時候存進去把1變3的，
+              照理說user這個物件是在wss connection連接的時候就已經把所屬的ws塞進去了，
+              我也沒有在斷線的時候，把對方所屬的readyState塞進去user裡，應該是不會被更新成3?
+              用console發現好像是對方斷線的時候，會自動連動更新原本存在user裡的readyState?
+              */
+              if (user[chattedUser].readyState === 1) {
+                user[chattedUser].send(data)
+                ws.send('發送成功')
+              } else {
+                ws.send('對方斷線')
+              }
+            } else {
+              ws.send('找不到被聊天的使用者')
+            }
+          } else { // 如果沒有被聊天的對象，就會變成群聊發送
+            let clients = wss.clients
+            // 聊天室裡會有很多人，所以用迴圈發訊息給所有Client
+            clients.forEach(client=> {
+              if (client !==ws && client.readyState === WebSocket.Open) {
+                client.send(data)
+              }
+              
+            })
+          }
+        })
+        
+        // 連結關閉時執行
+        ws.on('close', () => {
+          console.log('Close connected ')
+          // console.log(user)
+          // [待開發]最後把所有的聊天訊息存到資料庫(要另外新建一張資料表專門存訊息)
+
+        })
+      })
+    }
+}
+
+module.exports = websocket

--- a/config/websocketConfig.js
+++ b/config/websocketConfig.js
@@ -1,6 +1,3 @@
-// const SocketServer = require('ws').Server
-
-
 const websocket = {
   websocket: function (app, sessionParser) {
     const Websocket = require('ws')
@@ -14,6 +11,8 @@ const websocket = {
       console.log('通過連接'+ infoUrl)
       return true
     } 
+    
+    // const wss = new Websocket.Server({ server, verifyClient: verifyClientFn })
     const wss = new Websocket.Server({ port: 3001, clientTracking: false, noserver: true, verifyClient: verifyClientFn })
     
     server.on('upgrade', function (request, socket, head) {

--- a/config/websocketConfig.js
+++ b/config/websocketConfig.js
@@ -7,7 +7,7 @@ const websocket = {
     
     const verifyClientFn = function(info) {
       console.log(info.req.headers.cookie)
-      let infoUrl = info.req.url
+      let infoUrl = info.req
       console.log('通過連接'+ infoUrl)
       return true
     } 
@@ -15,20 +15,7 @@ const websocket = {
     // const wss = new Websocket.Server({ server, verifyClient: verifyClientFn })
     const wss = new Websocket.Server({ port: 3001, clientTracking: false, noserver: true, verifyClient: verifyClientFn })
     
-    server.on('upgrade', function (request, socket, head) {
-      console.log(`parsing session from request...`)
-      sessionParser(request, {}, () => {
-        console.log('websocket拿到的', request.session)
-        if (!request.session.userId) {
-          socket.destroy()
-          return
-        }
-        console.log('session is parsed!')
-        wss.handleUpgrade(request, socket, head, function (ws) {
-          wss.emit('connection', ws, request)
-        })
-      })
-    })
+    
 
     wss.on('connection', function (ws, request) {
       console.log('連接建立')
@@ -45,6 +32,21 @@ const websocket = {
 
       ws.on('close', function () {
         map.delete(userId)
+      })
+    })
+
+    server.on('upgrade', function (request, socket, head) {
+      console.log(`parsing session from request...`)
+      sessionParser(request, {}, () => {
+        console.log('websocket拿到的', request.session)
+        if (!request.session.userId) {
+          socket.destroy()
+          return
+        }
+        console.log('session is parsed!')
+        wss.handleUpgrade(request, socket, head, function (ws) {
+          wss.emit('connection', ws, request)
+        })
       })
     })
 

--- a/config/websocketConfig.js
+++ b/config/websocketConfig.js
@@ -7,7 +7,7 @@ const websocket = {
     
     const verifyClientFn = function(info) {
       console.log(info.req.headers.cookie)
-      let infoUrl = info.req
+      let infoUrl = info.req.session.userId
       console.log('通過連接'+ infoUrl)
       return true
     } 
@@ -15,8 +15,6 @@ const websocket = {
     // const wss = new Websocket.Server({ server, verifyClient: verifyClientFn })
     const wss = new Websocket.Server({ port: 3001, clientTracking: false, noserver: true, verifyClient: verifyClientFn })
     
-    
-
     wss.on('connection', function (ws, request) {
       console.log('連接建立')
       ws.send('連接建立')

--- a/config/websocketConfig.js
+++ b/config/websocketConfig.js
@@ -6,7 +6,13 @@ const websocket = {
       let online = 0 // 在線人數
       
       //把app交給SocketServer開啟 WebSocket 的服務
-      const wss = new SocketServer({ server })
+      const wss = new SocketServer({ server , verifyClient: yan})
+      function yan(info) {
+        console.log(info.req.headers.cookie)
+        let infoUrl = info.req.url
+        console.log('通過連接'+ infoUrl)
+        return true
+      } 
 
       // 當WebSocket從外面連結時執行
       wss.on('connection', (ws, req) => {
@@ -21,7 +27,7 @@ const websocket = {
         if (chatHost) {
           user[chatHost] = ws
         }
-        console.log(user)
+        // console.log(user)
         let chattedUser = url.split('/')[3] //被聊天的對象的id
         
         // [待開發]首次連接就先去撈歷史訊息給Client
@@ -30,7 +36,6 @@ const websocket = {
         ws.on('message', data => {
           console.log('收到' + url + '的消息'+ data)
           // 判斷有沒有被聊天的對象
-          console.log(user)
           if(chattedUser) {
             // 會去查看被聊天的對象有沒有被存在user裡了
             if (user[chattedUser]) {
@@ -40,8 +45,10 @@ const websocket = {
               用console發現好像是對方斷線的時候，會自動連動更新原本存在user裡的readyState?
               */
               if (user[chattedUser].readyState === 1) {
-                user[chattedUser].send(data)
+                user[chattedUser].send(data) // 把訊息送給被聊天的對象
+                ws.send(data) // 也把訊息送回給發起聊天的人
                 ws.send('發送成功')
+                
               } else {
                 ws.send('對方斷線')
               }

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -11,9 +11,6 @@ const imgur = require('imgur-node-api')
 const IMGUR_CLIENT_ID = 'a145f3a2c4d12e7'
 const moment = require("moment")
 
-
-
-
 const userController = {
   signUpPage: (req, res) => {
     res.render('signup')

--- a/package-lock.json
+++ b/package-lock.json
@@ -2282,6 +2282,11 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
+    "ws": {
+      "version": "7.2.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.2.3.tgz",
+      "integrity": "sha512-HTDl9G9hbkNDk98naoR/cHDws7+EyYMOdL1BmjsZXRUjf7d+MficC4B7HLUPlSiho0vg+CWKrGIt/VJBd1xunQ=="
+    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -954,6 +954,11 @@
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.7.6.tgz",
       "integrity": "sha1-YPvZBFV1Qc0rh5Wr8wihs3cOFVo="
     },
+    "http": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/http/-/http-0.0.0.tgz",
+      "integrity": "sha1-huYybSnF0Dnen6xYSkVon5KfT3I="
+    },
     "http-errors": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
@@ -1873,6 +1878,11 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
         }
       }
     },
@@ -2194,9 +2204,9 @@
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+      "integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
     },
     "validator": {
       "version": "10.10.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "express-handlebars": "^3.0.0",
     "express-session": "^1.15.6",
     "faker": "^4.1.0",
+    "http": "0.0.0",
     "imgur-node-api": "^0.1.0",
     "method-override": "^3.0.0",
     "mocha": "^6.0.2",
@@ -32,6 +33,7 @@
     "sequelize-cli": "^5.5.0",
     "sinon": "^7.2.3",
     "sinon-chai": "^3.3.0",
+    "uuid": "^7.0.2",
     "ws": "^7.2.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "sequelize": "^4.42.0",
     "sequelize-cli": "^5.5.0",
     "sinon": "^7.2.3",
-    "sinon-chai": "^3.3.0"
+    "sinon-chai": "^3.3.0",
+    "ws": "^7.2.3"
   },
   "devDependencies": {
     "sequelize-test-helpers": "^1.0.7",

--- a/public/javascripts/client.js
+++ b/public/javascripts/client.js
@@ -1,5 +1,8 @@
+const url = 'ws://' + window.location.href.substring(7)
+console.log(url)
+
 // 使用WebSocket的網址向Server開啟連結
-let ws = new WebSocket('ws://localhost:3000/')
+let ws = new WebSocket(url)
 
 // 開啟連結後執行的動作
 ws.onopen = () => {

--- a/public/javascripts/client.js
+++ b/public/javascripts/client.js
@@ -1,0 +1,18 @@
+// 使用WebSocket的網址向Server開啟連結
+let ws = new WebSocket('ws://localhost:3000/')
+
+// 開啟連結後執行的動作
+ws.onopen = () => {
+    console.log('open connection')
+}
+
+// 關閉連結後執行
+ws.onclose = () => {
+    console.log('close connection')
+}
+
+// 接收Server發出的訊息
+ws.onmessage = event => {
+    // 如果要接收Server送出來的data值，則是要用event.data去拿
+    console.log(event)
+}

--- a/public/javascripts/client.js
+++ b/public/javascripts/client.js
@@ -11,8 +11,21 @@ ws.onclose = () => {
     console.log('close connection')
 }
 
+const messagesPrint = document.querySelector('#messagesPrint')
+const messageForm = document.querySelector('#messageForm')
+const messageInput = document.querySelector('#messageInput')
+let messagesStored = []
+let allHtml = ``
 // 接收Server發出的訊息
 ws.onmessage = event => {
-    // 如果要接收Server送出來的data值，則是要用event.data去拿
-    console.log(event)
+    // 把拿到的訊息送去HTML印出
+    let eachHtml = `<li>${event.data}</li>`
+    allHtml += eachHtml
+    messagesPrint.children[0].innerHTML = allHtml
 }
+
+messageForm.addEventListener('submit', event => {
+    event.preventDefault()
+    ws.send(messageInput.value)
+})
+

--- a/public/javascripts/client.js
+++ b/public/javascripts/client.js
@@ -2,14 +2,14 @@ const url = 'ws://' + window.location.href.substring(7)
 console.log(url)
 
 // 使用WebSocket的網址向Server開啟連結
-let ws = new WebSocket(url)
+let ws = new WebSocket(url) // 這邊的網址都會是一樣!!!
 
-// 開啟連接後執行的動作
+// 開啟連結後執行的動作
 ws.onopen = () => {
     console.log('open connection')
 }
 
-// 關閉連接後執行
+// 關閉連結後執行
 ws.onclose = () => {
     console.log('close connection')
 }

--- a/public/javascripts/client.js
+++ b/public/javascripts/client.js
@@ -4,12 +4,12 @@ console.log(url)
 // 使用WebSocket的網址向Server開啟連結
 let ws = new WebSocket(url)
 
-// 開啟連結後執行的動作
+// 開啟連接後執行的動作
 ws.onopen = () => {
     console.log('open connection')
 }
 
-// 關閉連結後執行
+// 關閉連接後執行
 ws.onclose = () => {
     console.log('close connection')
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -53,4 +53,8 @@ module.exports = (app, passport) => {
   app.delete("/admin/tweets/:id", authenticatedAdmin, adminController.deleteTweet)
   app.get("/admin/users", authenticatedAdmin, adminController.getUsers)
 
+  // privateChat
+  app.get('/chat', (req, res) => {
+    res.render('chat')
+  })
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -54,7 +54,8 @@ module.exports = (app, passport) => {
   app.get("/admin/users", authenticatedAdmin, adminController.getUsers)
 
   // privateChat
-  app.get('/chat', (req, res) => {
+  // :hostChatId表示發起聊天的人(即當前登入的使用者)， :id表示被聊天的對象
+  app.get('/chat/:hostChatId/:id', /*authenticated,*/ (req, res) => {
     res.render('chat')
   })
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -54,17 +54,14 @@ module.exports = (app, passport) => {
   app.get("/admin/users", authenticatedAdmin, adminController.getUsers)
 
   // privateChat
-  const uuid = require('uuid')
+  
   // :hostChatId表示發起聊天的人(即當前登入的使用者)， :id表示被聊天的對象
   app.get('/chat/:hostChatId/:id', /*authenticated,*/(req, res) => {
     //
     // "Log in" user and set userId to session.
     //
-    const id = uuid.v4()
-
-    console.log(`updating session for user ${id}`)
-    req.session.userId = id
-    console.log(req.session)
+    req.session.userId = '123'
+    console.log('在chat路由', req.session)
     // res.send({result: 'OK', message: 'Session updated'})
     return res.render('chat')
     

--- a/routes/index.js
+++ b/routes/index.js
@@ -55,7 +55,11 @@ module.exports = (app, passport) => {
 
   // privateChat
   // :hostChatId表示發起聊天的人(即當前登入的使用者)， :id表示被聊天的對象
-  app.get('/chat/:hostChatId/:id', /*authenticated,*/ (req, res) => {
-    res.render('chat')
+  app.get('/chat/:hostChatId/:id', authenticated, (req, res) => {
+    if (Number(req.user.id) === Number(req.params.hostChatId)) {
+          res.render('chat')
+        } else {
+          return res.redirect('back')
+        }
   })
 }

--- a/routes/index.js
+++ b/routes/index.js
@@ -54,9 +54,20 @@ module.exports = (app, passport) => {
   app.get("/admin/users", authenticatedAdmin, adminController.getUsers)
 
   // privateChat
+  const uuid = require('uuid')
   // :hostChatId表示發起聊天的人(即當前登入的使用者)， :id表示被聊天的對象
   app.get('/chat/:hostChatId/:id', /*authenticated,*/(req, res) => {
-    return res.redirect('back')
+    //
+    // "Log in" user and set userId to session.
+    //
+    const id = uuid.v4()
+
+    console.log(`updating session for user ${id}`)
+    req.session.userId = id
+    console.log(req.session)
+    // res.send({result: 'OK', message: 'Session updated'})
+    return res.render('chat')
+    
   })
   //   if (Number(req.user.id) === Number(req.params.hostChatId)) {
   //         res.render('chat')

--- a/routes/index.js
+++ b/routes/index.js
@@ -55,11 +55,13 @@ module.exports = (app, passport) => {
 
   // privateChat
   // :hostChatId表示發起聊天的人(即當前登入的使用者)， :id表示被聊天的對象
-  app.get('/chat/:hostChatId/:id', authenticated, (req, res) => {
-    if (Number(req.user.id) === Number(req.params.hostChatId)) {
-          res.render('chat')
-        } else {
-          return res.redirect('back')
-        }
+  app.get('/chat/:hostChatId/:id', /*authenticated,*/(req, res) => {
+    return res.redirect('back')
   })
+  //   if (Number(req.user.id) === Number(req.params.hostChatId)) {
+  //         res.render('chat')
+  //       } else {
+  //         return res.redirect('back')
+  //       }
+  // })
 }

--- a/views/chat.handlebars
+++ b/views/chat.handlebars
@@ -1,0 +1,7 @@
+<html>
+    <body>
+        <h1>聊天室</h1>
+        <script src='./index.js'></script>
+    </body>
+    <script src="/javascripts/client.js"></script>
+</html>

--- a/views/chat.handlebars
+++ b/views/chat.handlebars
@@ -1,6 +1,20 @@
 <html>
     <body>
         <h1>聊天室</h1>
+        <div>
+            <div id="messagesPrint">
+                <ul>
+
+                </ul>
+            </div>
+            <form action="/chat" method="POST" id="messageForm">
+                <label for="messageInput"></label>
+                <textarea name="messageInput" id="messageInput" cols="30" rows="10" placeholder="請輸入訊息"></textarea>
+                <button type="submit" id="submitMessage">送出</button>
+            </form>
+            
+        </div>
+        
         <script src='./index.js'></script>
     </body>
     <script src="/javascripts/client.js"></script>

--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -56,5 +56,4 @@
   integrity="sha384-ZMP7rVo3mIykV+2+9J3UJ46jBk0WLaUAdn689aCwoqbBJiSnjAK/l8WvCWPIPm49" crossorigin="anonymous"></script>
 <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.1.3/js/bootstrap.min.js"
   integrity="sha384-ChfqqxuZUCnJSK3+MXmPNIyE6ZbWh2IMqE241rYiqJxyMiZ6OW/JmZQ5stwEULTy" crossorigin="anonymous"></script>
-
 </html>

--- a/views/userTweets.handlebars
+++ b/views/userTweets.handlebars
@@ -30,8 +30,9 @@
             <button type="submit" class="btn btn-primary">Follow</button>
           </div>
         </form>
+        <a href="/chat/{{userInfo.id}}/{{User.id}}" class="btn btn-warning">Chat</a>
         {{/if}}
-
+        
         {{/ifCond}}
       </div>
     </div>


### PR DESCRIPTION
這邊是用了[官方的案例](https://github.com/websockets/ws/blob/master/examples/express-session-parse/index.js)想要試試看，但是失敗了。

1. 為何研究官方案例
因為原本privateChat1的寫法只在路由那邊做驗證，想說要在websocket裡面做驗證比較嚴謹，所以才來開始研究官方的寫法。
2. 基本概念
因為官方案例看起來是可以在路由先塞一個自創的session，接著傳到websocket讓server使用，想說如果我也可以成功傳送session，
那後面再來研究如何把我要的req.user.id包到session裡，我在websocket的時候做驗證。
不過目前我連傳送session這段都是失敗的Orz
3. 主要都寫在app.js了
有把我原本privatechat的寫法跟官方寫法一起放到app.js方便比較差異。
原本的寫法在app.js上半部，但已經被我註解掉。
4. 瀏覽器的console顯示連線已關閉
網址輸入localhost:3000/1/2畫面能夠渲染，但是可以在瀏覽器的console看到已經關閉連線了，很怪。
5. websocketConfig.js這隻不用看，這是原本在privatechat1時，我把一些websocket程式碼從app.js抽取出來獨立放。
